### PR TITLE
Drag to pan

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ equal, too.
 
 If you specify the `--gui` option (and have the TK bindings for PIL installed),
 a graphical user interface will open up in which you can explore the image. Use
-the scroll wheel to zoom in and out, and mouse around the image to explore the
-code. Quit with control-Q or control-W. When the GUI is finished, the intention
-is to have it be very similar to Google Maps, OpenStreetMap, or other map
-exploration interfaces.
+the scroll wheel to zoom in and out, click-and-drag to pan around, and mouse
+around the image to explore the code. Quit with control-Q or control-W. When
+the GUI is finished, the intention is to have it be very similar to Google
+Maps, OpenStreetMap, or other map exploration interfaces.
 
 If you don't specify `--gui`, the image will be saved to file. By default it
 goes in `output.png`, but you can specify a different place to put it with the


### PR DESCRIPTION
Changes include:

- The image is now displayed with a Canvas widget, rather than a Label. 
- The GUI is always a fixed size, no matter how much you zoom in or out.
- Panning works! Click and drag for that.
- The `_Gui` class has been split into a `_Gui` class (which puts all the pieces together) and a `_Map` class (which displays the image and deals with panning). There's still also a `ZoomMap` class that holds all the images that might be displayed and deals with zooming. It's unclear to me whether these should be merged. At the very least, I suspect one of them is misnamed.

I think the next step after this will be to limit the image to some reasonable subset of all the data, so this can be used on very large files without your computer falling over (and as you pan, we'd swap images in and out depending on which subset should be on the screen). It would also be nice to restrict panning off the sides of the image, so you never see the green background.

Remember to squash this PR before merging!